### PR TITLE
Fix character counting problems with utf8	

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,9 @@ def trans_coverage_file(file, ext=None):
         with open(file, "r") as myfile:
             s = myfile.read()
 
+            if type(s) == bytes:
+                s = s.decode('utf8')
+
             words, others = 0, 0
             for c in s:
                 if is_ascii(c):

--- a/sample.md
+++ b/sample.md
@@ -1,9 +1,9 @@
 # Translation Coverage                         
 (Automatically generated. DO NOT edit.)
-* [*/*](/) (81/109) [74%]
-  * [*/sample_kor.txt*](/sample_kor.txt) (45/45) [100%]
+* [/](/) (27/55) [49%]
+  * [*/sample_kor.txt*](/sample_kor.txt) (15/15) [100%]
   * [**/sample_eng.txt**](/sample_eng.txt) (0/11) [0%]
-  * [*/sample.txt*](/sample.txt) (36/53) [67%]
+  * [/sample.txt](/sample.txt) (12/29) [41%]
 
 ---
 Powered by [Translation Coverage](https://github.com/hunkim/translation_coverage)

--- a/tests/testMain.py
+++ b/tests/testMain.py
@@ -57,12 +57,8 @@ class TestUtilsMethods(unittest.TestCase):
         # `python main.py --dir tests > sample.md`
         with open("sample.md", "r") as sample:
             s1 = sample.read().splitlines()
-            out = main.print_out(args)
-            print(out)
-            s2 = out.splitlines()
-            # self.assertEqual(s1, s2)
-            # TODO: Weak test due to Python 2 and 3 text handling issue
-            self.assertEqual(len(s1), len(s2))
+            s2 = main.print_out(args).splitlines()
+            self.assertEqual(s1, s2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. Use 'utf8' only for counting characters in string
2. Modify `sample.md` had wrong count numbers.
3. Restore test
