### PR TITLE
Ignore the non-normal text when calculating the coverage

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from os import listdir
 from os.path import isfile, isdir, join
 from string import ascii_letters
 
-from reader import read_file_with_source_code
+from reader import read_normal_text_from_file
 from report import report_coverage
 
 print_que = []
@@ -18,9 +18,7 @@ def is_ascii(char):
 
 
 def trans_coverage_file(filename, ext_set=None):
-    text_content, text_normal = read_file_with_source_code(filename, ext_set)
-
-    non_normal_len = len(text_content) - len(text_normal)
+    text_normal = read_normal_text_from_file(filename, ext_set)
 
     eng_words, non_eng_words = 0, 0
 
@@ -31,7 +29,7 @@ def trans_coverage_file(filename, ext_set=None):
         else:
             non_eng_words += 1
 
-    return eng_words, non_eng_words, non_normal_len
+    return eng_words, non_eng_words
 
 
 def trans_coverage(depth, args, loc, ext_set=None, exclude_path=None):
@@ -45,28 +43,27 @@ def trans_coverage(depth, args, loc, ext_set=None, exclude_path=None):
         return 0, 0
 
     if isfile(loc):
-        eng_count, non_eng_count, non_normal_count = trans_coverage_file(
+        eng_count, non_eng_count = trans_coverage_file(
             loc, ext_set)
     elif isdir(loc):
-        eng_count, non_eng_count, non_normal_count = 0, 0, 0
+        eng_count, non_eng_count = 0, 0
 
         for f in sorted(listdir(loc), reverse=True):
             full_file = join(loc, f)
-            e_count, n_count, nn_count = trans_coverage(depth, args, full_file, ext_set,
-                                                        exclude_path)
+            e_count, n_count = trans_coverage(depth, args, full_file, ext_set,
+                                              exclude_path)
 
             eng_count += e_count
             non_eng_count += n_count
-            non_normal_count += nn_count
     else:
-        eng_count, non_eng_count, non_normal_count = 0, 0, 0
+        eng_count, non_eng_count = 0, 0
 
-    if eng_count is not 0 or non_eng_count is not 0 or non_normal_count is not 0:
+    if eng_count is not 0 or non_eng_count is not 0:
         out = report_coverage(
-            depth, args, loc, eng_count, non_eng_count, non_normal_count)
+            depth, args, loc, eng_count, non_eng_count)
         print_que.append(out)
 
-    return eng_count, non_eng_count, non_normal_count
+    return eng_count, non_eng_count
 
 
 def parse_args(args):

--- a/main.py
+++ b/main.py
@@ -18,25 +18,20 @@ def is_ascii(char):
 
 
 def trans_coverage_file(filename, ext_set=None):
-    text_content, text_non_source_code = read_file_with_source_code(filename, ext_set)
+    text_content, text_normal = read_file_with_source_code(filename, ext_set)
 
-    content_len = len(text_content)
-    non_source_code_len = len(text_non_source_code)
+    non_normal_len = len(text_content) - len(text_normal)
 
-    # Source code length will be added to 'others'
-    # This is not plain english
-    source_code_len = content_len - non_source_code_len
+    eng_words, non_eng_words = 0, 0
 
-    words, others = 0, 0
-
-    for c in text_non_source_code:
+    for c in text_normal:
         if is_ascii(c):
             if c in ascii_letters:
-                words += 1
+                eng_words += 1
         else:
-            others += 1
+            non_eng_words += 1
 
-    return words, others + source_code_len
+    return eng_words, non_eng_words, non_normal_len
 
 
 def trans_coverage(depth, args, loc, ext_set=None, exclude_path=None):
@@ -50,25 +45,28 @@ def trans_coverage(depth, args, loc, ext_set=None, exclude_path=None):
         return 0, 0
 
     if isfile(loc):
-        eng_count, noneng_count = trans_coverage_file(loc, ext_set)
+        eng_count, non_eng_count, non_normal_count = trans_coverage_file(
+            loc, ext_set)
     elif isdir(loc):
-        eng_count, noneng_count = 0, 0
+        eng_count, non_eng_count, non_normal_count = 0, 0, 0
 
         for f in sorted(listdir(loc), reverse=True):
             full_file = join(loc, f)
-            e_count, n_count = trans_coverage(depth, args, full_file, ext_set,
-                                              exclude_path)
+            e_count, n_count, nn_count = trans_coverage(depth, args, full_file, ext_set,
+                                                        exclude_path)
 
             eng_count += e_count
-            noneng_count += n_count
+            non_eng_count += n_count
+            non_normal_count += nn_count
     else:
-        eng_count, noneng_count = 0, 0
+        eng_count, non_eng_count, non_normal_count = 0, 0, 0
 
-    if eng_count is not 0 or noneng_count is not 0:
-        out = report_coverage(depth, args, loc, eng_count, noneng_count)
+    if eng_count is not 0 or non_eng_count is not 0 or non_normal_count is not 0:
+        out = report_coverage(
+            depth, args, loc, eng_count, non_eng_count, non_normal_count)
         print_que.append(out)
 
-    return eng_count, noneng_count
+    return eng_count, non_eng_count, non_normal_count
 
 
 def parse_args(args):

--- a/reader.py
+++ b/reader.py
@@ -6,23 +6,32 @@ def strip_source_code_from_with_md(text):
     return re.sub('```.*?```', '', text, flags=re.DOTALL)
 
 
-def read_file_with_source_code(filename, ext_set=None):
-    """Read the file and return the original text and non source code text
+def get_source_code_stripper(ext):
+    source_code_stripper = {
+        '.md': strip_source_code_from_with_md,
+        # Add stripper for other formats
+    }
+
+    if ext in source_code_stripper:
+        return source_code_stripper[ext]
+
+    # Return just original text
+    return lambda text: text
+
+
+def read_normal_text_from_file(filename, ext_set=None):
+    """Read the file and return the normal text
 
         Args:
             filename: full filename
             ext_set: available extensions
 
         Returns:
-            Tuple of original text and normal text without special string
+            normal text without special string (e.g. except source code)
     """
-    # Strip function dictionary for specific extension
-    source_code_stripper = {
-        '.md': strip_source_code_from_with_md,
-    }
 
     if ext_set is not None and not filename.lower().endswith(ext_set):
-        return '', ''
+        return ''
 
     try:
         with open(filename, 'r') as trans_file:
@@ -33,14 +42,10 @@ def read_file_with_source_code(filename, ext_set=None):
 
             ext = os.path.splitext(filename)[1]
 
-            # Store normal text except text with special meaning (e.g. source
-            # code)
-            text_normal = ''
+            source_code_stripper = get_source_code_stripper(ext)
 
-            # Except source code
-            if ext in source_code_stripper:
-                text_normal = source_code_stripper[ext](text_content)
+            text_normal = source_code_stripper(text_content)
 
-            return text_content, text_normal
+            return text_normal
     except:
-        return '', ''
+        return ''

--- a/reader.py
+++ b/reader.py
@@ -12,9 +12,9 @@ def read_file_with_source_code(filename, ext_set=None):
         Args:
             filename: full filename
             ext_set: available extensions
-            
+
         Returns:
-            Tuple of original text and text without source code
+            Tuple of original text and normal text without special string
     """
     # Strip function dictionary for specific extension
     source_code_stripper = {
@@ -33,12 +33,14 @@ def read_file_with_source_code(filename, ext_set=None):
 
             ext = os.path.splitext(filename)[1]
 
+            # Store normal text except text with special meaning (e.g. source
+            # code)
+            text_normal = ''
+
             # Except source code
             if ext in source_code_stripper:
-                text_non_source_code = source_code_stripper[ext](text_content)
-            else:
-                text_non_source_code = ''
+                text_normal = source_code_stripper[ext](text_content)
 
-            return text_content, text_non_source_code
+            return text_content, text_normal
     except:
         return '', ''

--- a/report.py
+++ b/report.py
@@ -4,7 +4,7 @@
 '''
 
 
-def report_coverage(depth, args, loc, eng_count, non_eng_count, non_normal_count):
+def report_coverage(depth, args, loc, eng_count, non_eng_count):
     indent = ""
     for i in range(depth):
         indent += args.indent
@@ -14,7 +14,7 @@ def report_coverage(depth, args, loc, eng_count, non_eng_count, non_normal_count
     if rel_loc == '':
         rel_loc = "/"
 
-    text_count = eng_count + non_eng_count + non_normal_count
+    text_count = eng_count + non_eng_count
 
     ratio = int(non_eng_count * 100 / text_count)
     # No translation

--- a/report.py
+++ b/report.py
@@ -4,7 +4,7 @@
 '''
 
 
-def report_coverage(depth, args, loc, eng_count, noneng_count):
+def report_coverage(depth, args, loc, eng_count, non_eng_count, non_normal_count):
     indent = ""
     for i in range(depth):
         indent += args.indent
@@ -14,12 +14,15 @@ def report_coverage(depth, args, loc, eng_count, noneng_count):
     if rel_loc == '':
         rel_loc = "/"
 
-    ratio = int(noneng_count * 100 / (eng_count + noneng_count))
+    text_count = eng_count + non_eng_count + non_normal_count
+
+    ratio = int(non_eng_count * 100 / text_count)
     # No translation
     style = "**" if ratio == 0 else "*" if ratio > 50 else ""
 
     return indent + args.prefix + \
-        "[" + style + rel_loc + style + "]" +\
-        "(" + rel_loc + ")" +\
-        args.suffix + " (" + str(noneng_count) + "/" + str(eng_count + noneng_count) + \
-        ") [" + str(ratio) + "%]"
+        "[" + style + rel_loc + style + "]" + \
+        "(" + rel_loc + ")" + \
+        args.suffix + \
+        " (" + str(non_eng_count) + "/" + str(text_count) + ")" + \
+        " [" + str(ratio) + "%]"

--- a/sample.md
+++ b/sample.md
@@ -1,10 +1,9 @@
 # Translation Coverage                         
 (Automatically generated. DO NOT edit.)
-* [/](/) (27/120) [22%]
-  * [/sample.md](/sample.md) (12/57) [21%]
+* [/](/) (27/55) [49%]
+  * [/sample.md](/sample.md) (12/29) [41%]
   * [**/sample_eng.md**](/sample_eng.md) (0/11) [0%]
   * [*/sample_kor.md*](/sample_kor.md) (15/15) [100%]
-  * [**/sample_source_code.md**](/sample_source_code.md) (0/37) [0%]
 
 ---
 Powered by [Translation Coverage](https://github.com/hunkim/translation_coverage)

--- a/sample.md
+++ b/sample.md
@@ -1,10 +1,10 @@
 # Translation Coverage                         
 (Automatically generated. DO NOT edit.)
-* [*/*](/) (92/120) [76%]
-  * [*/sample.md*](/sample.md) (40/57) [70%]
+* [/](/) (27/120) [22%]
+  * [/sample.md](/sample.md) (12/57) [21%]
   * [**/sample_eng.md**](/sample_eng.md) (0/11) [0%]
   * [*/sample_kor.md*](/sample_kor.md) (15/15) [100%]
-  * [*/sample_source_code.md*](/sample_source_code.md) (37/37) [100%]
+  * [**/sample_source_code.md**](/sample_source_code.md) (0/37) [0%]
 
 ---
 Powered by [Translation Coverage](https://github.com/hunkim/translation_coverage)

--- a/tests/testMain.py
+++ b/tests/testMain.py
@@ -21,43 +21,54 @@ class TestUtilsMethods(unittest.TestCase):
         self.assertEqual(main.is_ascii('金'), False)
 
     def test_trans_coverage_no_file(self):
-        e_count, n_count = main.trans_coverage_file("no_file.md")
-        print("No file: ", e_count, n_count)
+        e_count, n_count, nn_count = main.trans_coverage_file("no_file.md")
+        print("No file: ", e_count, n_count, nn_count)
         self.assertEqual(0, e_count)
         self.assertEqual(0, n_count)
+        self.assertEqual(0, nn_count)
 
     def test_trans_coverage_file(self):
-        e_count, n_count = main.trans_coverage_file("tests/sample.md")
-        print("sample: ", e_count, n_count)
+        e_count, n_count, nn_count = main.trans_coverage_file(
+            "tests/sample.md")
+        print("sample: ", e_count, n_count, nn_count)
         self.assertNotEqual(0, e_count)
         self.assertNotEqual(0, n_count)
+        self.assertNotEqual(0, nn_count)
 
     def test_trans_coverage_file_kor(self):
-        e_count, n_count = main.trans_coverage_file("tests/sample_kor.md")
-        print("sample_kor: ", e_count, n_count)
+        e_count, n_count, nn_count = main.trans_coverage_file(
+            "tests/sample_kor.md")
+        print("sample_kor: ", e_count, n_count, nn_count)
         self.assertEqual(0, e_count)
         self.assertNotEqual(0, n_count)
+        self.assertEqual(0, nn_count)
 
     def test_trans_coverage_file_eng(self):
-        e_count, n_count = main.trans_coverage_file("tests/sample_eng.md")
-        print("sample_eng: ", e_count, n_count)
+        e_count, n_count, nn_count = main.trans_coverage_file(
+            "tests/sample_eng.md")
+        print("sample_eng: ", e_count, n_count, nn_count)
         self.assertNotEqual(0, e_count)
         self.assertEqual(0, n_count)
+        self.assertEqual(0, nn_count)
 
     def test_trans_coverage_file_source_code(self):
-        e_count, n_count = main.trans_coverage_file("tests/sample_source_code.md")
-        print("sample_source_code: ", e_count, n_count)
+        e_count, n_count, nn_count = main.trans_coverage_file(
+            "tests/sample_source_code.md")
+        print("sample_source_code: ", e_count, n_count, nn_count)
         self.assertEqual(e_count, 0)
-        self.assertNotEqual(n_count, 0)
+        self.assertEqual(n_count, 0)
+        self.assertNotEqual(nn_count, 0)
 
     def test_trans_coverage(self):
         args = main.parse_args(["--dir=tests"])
         ext = tuple(args.ext.split())
 
-        e_count, n_count = main.trans_coverage(-1, args, "tests", ext)
-        print("test dir: ", e_count, n_count)
+        e_count, n_count, nn_count = main.trans_coverage(
+            -1, args, "tests", ext)
+        print("test dir: ", e_count, n_count, nn_count)
         self.assertNotEqual(0, e_count)
         self.assertNotEqual(0, n_count)
+        self.assertNotEqual(0, nn_count)
 
         # Generate/update sample file
         # `python main.py --dir tests > sample.md`

--- a/tests/testMain.py
+++ b/tests/testMain.py
@@ -21,54 +21,48 @@ class TestUtilsMethods(unittest.TestCase):
         self.assertEqual(main.is_ascii('金'), False)
 
     def test_trans_coverage_no_file(self):
-        e_count, n_count, nn_count = main.trans_coverage_file("no_file.md")
-        print("No file: ", e_count, n_count, nn_count)
+        e_count, n_count = main.trans_coverage_file("no_file.md")
+        print("No file: ", e_count, n_count)
         self.assertEqual(0, e_count)
         self.assertEqual(0, n_count)
-        self.assertEqual(0, nn_count)
 
     def test_trans_coverage_file(self):
-        e_count, n_count, nn_count = main.trans_coverage_file(
+        e_count, n_count = main.trans_coverage_file(
             "tests/sample.md")
-        print("sample: ", e_count, n_count, nn_count)
+        print("sample: ", e_count, n_count)
         self.assertNotEqual(0, e_count)
         self.assertNotEqual(0, n_count)
-        self.assertNotEqual(0, nn_count)
 
     def test_trans_coverage_file_kor(self):
-        e_count, n_count, nn_count = main.trans_coverage_file(
+        e_count, n_count = main.trans_coverage_file(
             "tests/sample_kor.md")
-        print("sample_kor: ", e_count, n_count, nn_count)
+        print("sample_kor: ", e_count, n_count)
         self.assertEqual(0, e_count)
         self.assertNotEqual(0, n_count)
-        self.assertEqual(0, nn_count)
 
     def test_trans_coverage_file_eng(self):
-        e_count, n_count, nn_count = main.trans_coverage_file(
+        e_count, n_count = main.trans_coverage_file(
             "tests/sample_eng.md")
-        print("sample_eng: ", e_count, n_count, nn_count)
+        print("sample_eng: ", e_count, n_count)
         self.assertNotEqual(0, e_count)
         self.assertEqual(0, n_count)
-        self.assertEqual(0, nn_count)
 
     def test_trans_coverage_file_source_code(self):
-        e_count, n_count, nn_count = main.trans_coverage_file(
+        e_count, n_count = main.trans_coverage_file(
             "tests/sample_source_code.md")
-        print("sample_source_code: ", e_count, n_count, nn_count)
-        self.assertEqual(e_count, 0)
-        self.assertEqual(n_count, 0)
-        self.assertNotEqual(nn_count, 0)
+        print("sample_source_code: ", e_count, n_count)
+        self.assertEqual(0, e_count)
+        self.assertEqual(0, n_count)
 
     def test_trans_coverage(self):
         args = main.parse_args(["--dir=tests"])
         ext = tuple(args.ext.split())
 
-        e_count, n_count, nn_count = main.trans_coverage(
+        e_count, n_count = main.trans_coverage(
             -1, args, "tests", ext)
-        print("test dir: ", e_count, n_count, nn_count)
+        print("test dir: ", e_count, n_count)
         self.assertNotEqual(0, e_count)
         self.assertNotEqual(0, n_count)
-        self.assertNotEqual(0, nn_count)
 
         # Generate/update sample file
         # `python main.py --dir tests > sample.md`


### PR DESCRIPTION
(#22) Ignore the non-normal text when calculating the coverage

## Update
~~1. `trans_coverage_file` returns 3 values, eng_words, non_eng_words and `non_normal_len`. `non_normal_len` represents the count of non-normal text. it will be not counted, but added to original text count value.~~
1. `trans_coverage_file` use only normal text without any special string.
2. Non-normal text (e.g. source code) are never counted.
3. Some variable names are changed a little bit.
4. Every code related to counting has been refactored including test code.
